### PR TITLE
Implementing changes to support new hardware platform

### DIFF
--- a/benchmark/kernel/base.rb
+++ b/benchmark/kernel/base.rb
@@ -5,6 +5,18 @@ require_relative '../../../z80-libraries/vars'
 BENCHMARKS = File.join(__dir__, "src")
 
 class KernelBenchmark
+    def load_map
+        Zemu::Debug.load_map("kernel_debug.map") do |s|
+            if /([0-9a-fA-F]+)\s+(\S+)/ =~ s
+                addr = "0x#{$1}"
+                label = $2
+                [label, addr]
+            else
+                nil
+            end
+        end
+    end
+    
     def start_instance(binary)
         binary_name = File.basename(binary, ".bin")
 
@@ -70,12 +82,15 @@ class KernelBenchmark
         max = 0
 
         num.times do
+            print "."
+
             val = yield
             total += val
 
             min = val if val < min
             max = val if val > max
         end
+        print "\n"
 
         avg = total.to_f / num.to_f
         avg = avg.round(2)
@@ -93,6 +108,9 @@ class KernelBenchmark
                 compile_test_code([File.join(BENCHMARKS, "#{m}.c")], "#{m}.bin")
 
                 @instance = start_instance("#{m}.bin")
+
+                print "#{m}: "
+                
                 avg, min, max = send(m)
                 @instance.quit
 

--- a/benchmark/kernel/interrupt.rb
+++ b/benchmark/kernel/interrupt.rb
@@ -1,7 +1,7 @@
 require_relative 'base'
 
 class InterruptBenchmarks < KernelBenchmark
-    TIMES = 20
+    TIMES = 40
 
     def benchmark_interrupt_rx
         # Get symbols.

--- a/benchmark/kernel/interrupt.rb
+++ b/benchmark/kernel/interrupt.rb
@@ -1,6 +1,8 @@
 require_relative 'base'
 
 class InterruptBenchmarks < KernelBenchmark
+    TIMES = 20
+
     def benchmark_interrupt_rx
         # Get symbols.
         kernel_symbols = load_map()
@@ -8,19 +10,11 @@ class InterruptBenchmarks < KernelBenchmark
         int_breakpoint_start = kernel_symbols.find_by_name("_interrupt_handler").address
         int_breakpoint_end = kernel_symbols.find_by_name("__interrupt_handler_end").address
 
-        # We expect to start executing at 0x8000,
-        # where the command-processor would reside normally.
-        @instance.break 0x8000, :program
-        
-        # Run, and expect to hit the breakpoint.
-        @instance.continue
-        @instance.remove_break 0x8000, :program
-
         # Set a breakpoint at the start and end of the ISR.
         @instance.break int_breakpoint_start, :program
         @instance.break int_breakpoint_end, :program
 
-        bench(5) do
+        bench(TIMES) do
             # Write a character to the serial port.
             @instance.serial_puts "A"
 
@@ -41,19 +35,11 @@ class InterruptBenchmarks < KernelBenchmark
         int_breakpoint_start = kernel_symbols.find_by_name("__timer_handler").address
         int_breakpoint_end = kernel_symbols.find_by_name("__timer_handler_end").address
 
-        # We expect to start executing at 0x8000,
-        # where the command-processor would reside normally.
-        @instance.break 0x8000, :program
-        
-        # Run, and expect to hit the breakpoint.
-        @instance.continue
-        @instance.remove_break 0x8000, :program
-
         # Set a breakpoint at the start and end of the ISR.
         @instance.break int_breakpoint_start, :program
         @instance.break int_breakpoint_end, :program
 
-        bench(5) do
+        bench(TIMES) do
             # Run, we should hit the ISR.
             @instance.continue 10000000
 
@@ -71,19 +57,11 @@ class InterruptBenchmarks < KernelBenchmark
         int_breakpoint_start = kernel_symbols.find_by_name("__timer_handler").address
         int_breakpoint_end = kernel_symbols.find_by_name("__timer_handler_end").address
 
-        # We expect to start executing at 0x8000,
-        # where the command-processor would reside normally.
-        @instance.break 0x8000, :program
-        
-        # Run, and expect to hit the breakpoint.
-        @instance.continue
-        @instance.remove_break 0x8000, :program
-
         # Set a breakpoint at the start and end of the ISR.
         @instance.break int_breakpoint_start, :program
         @instance.break int_breakpoint_end, :program
 
-        bench(10) do
+        bench(TIMES) do
             # Run, we should hit the ISR.
             @instance.continue 10000000
 

--- a/benchmark/kernel/interrupt.rb
+++ b/benchmark/kernel/interrupt.rb
@@ -3,12 +3,12 @@ require_relative 'base'
 class InterruptBenchmarks < KernelBenchmark
     def benchmark_interrupt_rx
         # Get symbols.
-        kernel_symbols = Zemu::Debug.load_map("kernel_debug.map")
+        kernel_symbols = load_map()
 
         int_breakpoint_start = kernel_symbols.find_by_name("_interrupt_handler").address
         int_breakpoint_end = kernel_symbols.find_by_name("__interrupt_handler_end").address
 
-        # We expect to start executing at 0x6000,
+        # We expect to start executing at 0x8000,
         # where the command-processor would reside normally.
         @instance.break 0x8000, :program
         
@@ -36,7 +36,7 @@ class InterruptBenchmarks < KernelBenchmark
 
     def benchmark_scheduler_single
         # Get symbols.
-        kernel_symbols = Zemu::Debug.load_map("kernel_debug.map")
+        kernel_symbols = load_map()
 
         int_breakpoint_start = kernel_symbols.find_by_name("__timer_handler").address
         int_breakpoint_end = kernel_symbols.find_by_name("__timer_handler_end").address
@@ -66,7 +66,7 @@ class InterruptBenchmarks < KernelBenchmark
 
     def benchmark_scheduler_two_tasks
         # Get symbols.
-        kernel_symbols = Zemu::Debug.load_map("kernel_debug.map")
+        kernel_symbols = load_map()
 
         int_breakpoint_start = kernel_symbols.find_by_name("__timer_handler").address
         int_breakpoint_end = kernel_symbols.find_by_name("__timer_handler_end").address

--- a/benchmark/kernel/serial.rb
+++ b/benchmark/kernel/serial.rb
@@ -12,9 +12,13 @@ class SerialBenchmarks < KernelBenchmark
         @instance.break swrite_start, :program
         @instance.break swrite_end, :program
 
-        bench(1) do
-            @instance.continue 10000
+        bench(40) do
+            @instance.continue 100000
             isr_cycles = @instance.continue 10000
+
+            # Read from serial port so that it's ready
+            # for the next time round.
+            @instance.serial_gets(1)
 
             isr_cycles
         end

--- a/benchmark/kernel/serial.rb
+++ b/benchmark/kernel/serial.rb
@@ -3,7 +3,7 @@ require_relative 'base'
 class SerialBenchmarks < KernelBenchmark
     def benchmark_serial_write
         # Get symbols.
-        kernel_symbols = Zemu::Debug.load_map("kernel_debug.map")
+        kernel_symbols = load_map()
 
         swrite_start = kernel_symbols.find_by_name("_driver_6850_tx").address
         swrite_end = kernel_symbols.find_by_name("_driver_6850_tx_done").address

--- a/benchmark/kernel/serial.rb
+++ b/benchmark/kernel/serial.rb
@@ -8,16 +8,6 @@ class SerialBenchmarks < KernelBenchmark
         swrite_start = kernel_symbols.find_by_name("_driver_6850_tx").address
         swrite_end = kernel_symbols.find_by_name("_driver_6850_tx_done").address
 
-        puts "%04x, %04x" % [swrite_start, swrite_end]
-
-        # We expect to start executing at 0x8000,
-        # where the command-processor would reside normally.
-        @instance.break 0x8000, :program
-        
-        # Run, and expect to hit the breakpoint.
-        @instance.continue
-        @instance.remove_break 0x8000, :program
-
         # Set a breakpoint at the start and end of the ISR.
         @instance.break swrite_start, :program
         @instance.break swrite_end, :program

--- a/benchmark/kernel/src/benchmark_scheduler_two_tasks.c
+++ b/benchmark/kernel/src/benchmark_scheduler_two_tasks.c
@@ -8,7 +8,7 @@ const char other_proc[4] = {
 
 void loop(void);
 
-void main()
+void main(void)
 {
     int fd = syscall_fopen("test.exe", FMODE_WRITE);
     syscall_fwrite(other_proc, 4, fd);

--- a/command/main.c
+++ b/command/main.c
@@ -125,8 +125,8 @@ void user_main(void)
     /* Clear screen, cursor to top-left. */
     puts("\033[2J\033[1;1H");
 
-    /* Green text on black background. */
-    puts("\033[32m");
+    /* Green text for that retro feel. */
+    puts("\033[0m\033[32m");
 
     puts("ZEBRA Command Processor (v0.1.2)\n\r");
     printf("ZEBRA Kernel version: v%s\r\n", sysinfo->version);

--- a/kernel/driver_8254.asm
+++ b/kernel/driver_8254.asm
@@ -1,0 +1,31 @@
+    ; 8254 Programmable Timer drivers.
+    .equ    TIMER_0, 0x10
+    .equ    TIMER_CTRL, 0x13
+
+    ; At 3.686400 MHz each cycle is ~0.27us.
+    ; 60,000 cycles is ~16.28ms.
+    .equ    TIMER_COUNT, 60000
+
+    ; void timer_init(void)
+    ;
+    ; Initializes timer 0 as recurring interrupt timer.
+    .globl _timer_init
+_timer_init:
+    ; format is:
+    ;     sc:rw:mmm:b
+    ;
+    ; sc = 0  (select timer 0)
+    ; rw = 3  (r/w both bytes)
+    ; m = 0   (mode 0)
+    ; b = 0   (binary counter)
+    ;
+    ld      A, #0b00110000
+    out     (TIMER_CTRL), A
+
+    ; Write initial count.
+    ld      C, #TIMER_0
+    ld      HL, #TIMER_COUNT
+    out     (C), L ; lsb
+    out     (C), H ; msb
+
+    ret

--- a/kernel/driver_8254.asm
+++ b/kernel/driver_8254.asm
@@ -3,8 +3,17 @@
     .equ    TIMER_CTRL, 0x13
 
     ; At 3.686400 MHz each cycle is ~0.27us.
-    ; 60,000 cycles is ~16.28ms.
-    .equ    TIMER_COUNT, 60000
+    ;
+    ; Using a count of 61,440 results in a period of:
+    ;     16.6ms
+    ;
+    ; We context-switch every 6 counts, resulting in
+    ; a period of:
+    ;     99.999999959ms
+    ;
+    ; Ideal period is 100ms therefore error is:
+    ;     0.041ns
+    .equ    TIMER_COUNT, 61440
 
     ; void timer_init(void)
     ;

--- a/kernel/driver_8254.asm
+++ b/kernel/driver_8254.asm
@@ -22,10 +22,17 @@ _timer_init:
     ld      A, #0b00110000
     out     (TIMER_CTRL), A
 
-    ; Write initial count.
+    call    _timer_reset
+
+    ret
+
+    ; void timer_reset(void)
+    ;
+    ; Resets timer 0 to initial count.
+    .globl _timer_reset
+_timer_reset:
     ld      C, #TIMER_0
     ld      HL, #TIMER_COUNT
     out     (C), L ; lsb
     out     (C), H ; msb
-
     ret

--- a/kernel/include/driver_8254.h
+++ b/kernel/include/driver_8254.h
@@ -1,0 +1,5 @@
+/* timer_init
+ *
+ * Initializes timer 0 as recurring interrupt timer.
+ */
+void timer_init(void);

--- a/kernel/include/interrupt.h
+++ b/kernel/include/interrupt.h
@@ -1,6 +1,8 @@
 #ifndef _INTERRUPT_H
 #define _INTERRUPT_H
 
+void interrupt_init(void);
+
 void interrupt_enable(void);
 void interrupt_disable(void);
 void interrupt_tx_enable(void);

--- a/kernel/integration_test/test_process.rb
+++ b/kernel/integration_test/test_process.rb
@@ -256,7 +256,7 @@ class ProcessTest < IntegrationTest
         #
         # The spawned process runs forever so we are definitely
         # testing for concurrency.
-        @instance.continue 1000000
+        @instance.continue 2000000
         assert !@instance.halted?, "Hit unexpected HALT (bank %d, addr %04x, ret %d)" % [@instance.device("banked_ram").bank, @instance.registers["PC"], @instance.device("banked_ram").contents(0)[val_addr - 0x8000]]
         assert !@instance.break?, "Hit unexpected BREAK"
 

--- a/kernel/integration_test/test_sio.rb
+++ b/kernel/integration_test/test_sio.rb
@@ -97,7 +97,7 @@ class SIOTest < IntegrationTest
         @instance.serial_puts(0x18.chr)
 
         # Now run and expect to halt on the next scheduler tick.
-        @instance.continue 200000
+        @instance.continue 400000
         assert @instance.halted?, "Program did not halt when expected (at address %04x)" % @instance.registers["PC"]
 
         # Check return value.
@@ -115,7 +115,7 @@ class SIOTest < IntegrationTest
         @instance.serial_puts(0x18.chr)
 
         # Now run and expect to halt on the next scheduler tick.
-        @instance.continue 200000
+        @instance.continue 400000
         assert @instance.halted?, "Program did not halt when expected (at address %04x)" % @instance.registers["PC"]
 
         # Check return value.
@@ -135,29 +135,34 @@ class SIOTest < IntegrationTest
         # Run for some time - we expect not to halt.
         # It takes a while to write the child process to disk.
         assert_running(cycles: 10000000)
+        assert_equal 1, @instance.device("banked_ram").bank
 
         # Send a character to the serial terminal.
         # This should be received by the child process.
         @instance.serial_puts('A')
-        assert_running(cycles: 200000)
+        assert_running(cycles: 400000)
+        assert_equal 1, @instance.device("banked_ram").bank
 
         # Send break character - 0x18.
         @instance.serial_puts(0x18.chr)
 
         # Now run and expect not to halt.
         # We should have returned to the parent process.
-        assert_running(cycles: 200000)
+        assert_running(cycles: 1000000)
+        assert_equal 0, @instance.device("banked_ram").bank
 
         # Send a character to the serial terminal.
         # This should be received by the parent process.
         @instance.serial_puts('B')
-        assert_running(cycles: 200000)
+        assert_running(cycles: 400000)
+        assert_equal 0, @instance.device("banked_ram").bank
 
         # Send another break character.
         @instance.serial_puts(0x18.chr)
 
         # Continue - program should continue until completion.
-        @instance.continue 200000
+        @instance.continue 10000000
+        assert_equal 0, @instance.device("banked_ram").bank
         assert_program_finished
 
         # Check return value.
@@ -184,18 +189,18 @@ class SIOTest < IntegrationTest
 
         # Now run and expect not to halt.
         # We should have returned to the parent process.
-        assert_running(cycles: 200000)
+        assert_running(cycles: 1000000)
 
         # Send a character to the serial terminal.
         # This should be received by the parent process.
         @instance.serial_puts('C')
-        assert_running(cycles: 200000)
+        assert_running(cycles: 1000000)
 
         # Send another break character.
         @instance.serial_puts(0x18.chr)
 
         # Continue - program should continue until completion.
-        @instance.continue 200000
+        @instance.continue 4000000
         assert_program_finished
 
         # Check return value.

--- a/kernel/interrupt.asm
+++ b/kernel/interrupt.asm
@@ -9,6 +9,14 @@
 _interrupt_init:
     ld      A, #0
     ld      (__interrupt_timer_ticks), A
+
+    ; Switch to alternate register set and initialize
+    ; pointer registers.
+    exx
+    ld      HL, #__interrupt_timer_ticks
+
+    ; Switch back and return.
+    exx
     ret
 
 
@@ -68,8 +76,10 @@ __interrupt_handler_end:
 
 __serial_read_handler:
     ; Read data from UART and send to terminal.
+    push    HL
     in      A, (UART_PORT_DATA)
     call    _terminal_put
+    pop     HL
     
     jp      __interrupt_handle_ret
 
@@ -90,7 +100,6 @@ __interrupt_timer_ticks:
 
 __timer_handler:
     ; Increment tick count.
-    ld      HL, #__interrupt_timer_ticks
     inc     (HL)
 
     ; Skip timer handler if we are currently executing in kernel space.

--- a/kernel/interrupt.asm
+++ b/kernel/interrupt.asm
@@ -25,10 +25,6 @@ _interrupt_handler:
 
     call    _status_set_int
 
-    ; Get return address (TOS) into HL.
-    pop     HL
-    push    HL ; Don't forget to restore it!
-
     ; Is this an interrupt from the #6850?
     in      A, (UART_PORT_CONTROL)
     bit     #7, A
@@ -94,9 +90,8 @@ __interrupt_timer_ticks:
 
 __timer_handler:
     ; Increment tick count.
-    ld      A, (__interrupt_timer_ticks)
-    inc     A
-    ld      (__interrupt_timer_ticks), A
+    ld      HL, #__interrupt_timer_ticks
+    inc     (HL)
 
     ; Skip timer handler if we are currently executing in kernel space.
     call    _status_is_set_kernel
@@ -106,13 +101,12 @@ __timer_handler:
     ; Check tick count.
     ; We only context-switch a minimum of every 6 ticks
     ; so that we don't overload the processor.
-    ld      A, (__interrupt_timer_ticks)
+    ld      A, (HL)
     cp      #6
     jp      c, __timer_handler_end
 
     ; Reset tick count.
-    ld      A, #0
-    ld      (__interrupt_timer_ticks), A
+    ld      (HL), #0
 
 
 

--- a/kernel/interrupt.asm
+++ b/kernel/interrupt.asm
@@ -93,21 +93,22 @@ __interrupt_timer_ticks:
     .byte   0
 
 __timer_handler:
+    ; Increment tick count.
+    ld      A, (__interrupt_timer_ticks)
+    inc     A
+    ld      (__interrupt_timer_ticks), A
+
     ; Skip timer handler if we are currently executing in kernel space.
     call    _status_is_set_kernel
     cp      #0
     jp      nz, __timer_handler_end
 
-
-
-    ; Increment tick count. We only context-switch
-    ; every 6 ticks so that we don't overload the processor.
+    ; Check tick count.
+    ; We only context-switch a minimum of every 6 ticks
+    ; so that we don't overload the processor.
     ld      A, (__interrupt_timer_ticks)
-    inc     A
-    ld      (__interrupt_timer_ticks), A
-
     cp      #6
-    jp      nz, __timer_handler_end
+    jp      c, __timer_handler_end
 
     ; Reset tick count.
     ld      A, #0

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -26,6 +26,8 @@
 #include <include/memory.h>
 #include <include/scheduler.h>
 
+#include <include/driver_8254.h>
+
 extern SysInfo_T sysinfo;
 
 char input[256];
@@ -102,6 +104,8 @@ void main(void)
 
     int e2 = process_spawn(pd, NULL, 0);
 #endif
+
+    timer_init();
 
     status_clr_kernel();
     interrupt_enable();

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <syscall.h>
 
+#include <include/interrupt.h>
 #include <include/status.h>
 #include <include/file.h>
 #include <include/disk.h>
@@ -36,8 +37,6 @@ uint8_t startup_flags;
 
 typedef void (*proc_t)(void);
 
-void interrupt_disable(void);
-void interrupt_enable(void);
 void debug_process_run(void);
 
 extern const char kernel_version;
@@ -45,6 +44,7 @@ extern const char kernel_version;
 void main(void)
 {
     interrupt_disable();
+    interrupt_init();
 
     status_init();
     status_set_kernel();

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -70,6 +70,11 @@ void main(void)
     terminal_init();
 
 #ifndef DEBUG
+    for (int i = 0; i < sysinfo.numbanks; i++)
+    {
+        puts(".");
+    }
+    puts("\r\n");
     //printf("Z80-OS KERNEL v%s\r\n", &kernel_version);
     //printf("Memory: %d banks\r\n", (int)sysinfo.numbanks);
 

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -30,6 +30,7 @@ void scheduler_init(void)
 #ifdef DEBUG
     schedule_table[0].state = TASK_READY;
     schedule_table[0].pid = 0;
+    current_scheduled = 0;
     num_scheduled = 1;
 #endif
 }
@@ -128,6 +129,14 @@ int scheduler_current_pid(void)
 
 int scheduler_next(void)
 {
+    /* Special case - if there is only one scheduled process
+     * and it is running, then nothing needs to change.
+     */
+    if (num_scheduled == 1 && current_scheduled >= 0 && schedule_table[current_scheduled].state == TASK_RUNNING)
+    {
+        return schedule_current_pid;
+    }
+
     if (current_scheduled >= 0 && schedule_table[current_scheduled].state == TASK_RUNNING)
     {
         schedule_table[current_scheduled].state = TASK_READY;
@@ -151,9 +160,9 @@ int scheduler_next(void)
 
 uint8_t scheduler_tick(void)
 {
-    int pid = scheduler_next();
+    scheduler_next();
 
-    const ProcessDescriptor_T * p = process_info(pid);
+    const ProcessDescriptor_T * p = process_current();
 
     return p->bank;
 }

--- a/kernel/terminal.c
+++ b/kernel/terminal.c
@@ -19,9 +19,9 @@ void terminal_init(void)
 }
 
 /* Gets terminal status of the current process. */
-termstatus_t terminal_status(void)
+inline termstatus_t terminal_status(void)
 {
-    ProcessDescriptor_T * p = process_current();
+    ProcessDescriptor_T * const p = process_current();
     return p->termstatus;
 }
 

--- a/rakefile
+++ b/rakefile
@@ -515,6 +515,8 @@ class Function
     end
 
     def coverage
+        return 0.0 if num_covered.zero?
+        
         (num_covered.to_f / num_instrs.to_f) * 100
     end
 end

--- a/rakefile
+++ b/rakefile
@@ -646,6 +646,10 @@ namespace 'benchmark' do
     end
 end
 
+task "benchmark" => ["benchmark:kernel"]
+
 task "test" => ["test:kernel:all"] + BUILTINS.map { |_, name| "test:builtin:#{name}" }
 
 task "install", [:path] => ["install:kernel", "install:command"] + Dir.glob("builtin/*").map { |builtin| "install:builtin:#{File.basename(builtin)}" }
+
+task :default => ["test", "benchmark"]

--- a/rakefile
+++ b/rakefile
@@ -232,6 +232,8 @@ task 'debug' => ['build:kernel', 'build:command'] + BUILTINS.map{ |b| "build:bui
         FileUtils.cp("#{name}.exe", VIRTDISK)
     end
 
+    sleep(5)
+
     zemu_start()
 end
 

--- a/zemu/config.rb
+++ b/zemu/config.rb
@@ -272,7 +272,7 @@ class Timer8254 < Displayable
 
                 msb = val
                 initial_count = (msb << 8) | @lsb
-                @next_count = val
+                @next_count = initial_count
 
                 @lsb = nil
             end

--- a/zemu/config.rb
+++ b/zemu/config.rb
@@ -264,20 +264,18 @@ class Timer8254 < Displayable
             @out = 0
             
             if @lsb.nil?
-                log "Load lsb: %08x" % val
+                log "Load lsb: 0x%02x" % val
 
                 @lsb = val
             else
-                log "Load msb: %08x" % val
+                log "Load msb: 0x%02x" % val
 
                 msb = val
                 initial_count = (msb << 8) | @lsb
                 @next_count = val
-            end
-        end
 
-        def load_count(val)
-            @next_count = val
+                @lsb = nil
+            end
         end
 
         def tick
@@ -288,12 +286,12 @@ class Timer8254 < Displayable
             # Otherwise, loads the count into the timer.
             if @next_count.nil?
                 if @count == 0
-                    log "count zero"
                     @out = 1
                 elsif !@count.nil?
                     @count -= 1
                 end
             else
+                log "load new count: #{@next_count}"
                 @count = @next_count
                 @next_count = nil
             end

--- a/zemu/config.rb
+++ b/zemu/config.rb
@@ -377,6 +377,14 @@ class Timer8254 < Displayable
         cycles.times do
             @timers.each { |t| t.tick() }
         end
+
+        # All timer OUTs are ORed
+        # to INT.
+        if @timers.any? { |t| t.out == 1 }
+            interrupt(true)
+        else
+            interrupt(false)
+        end
     end
 end
 

--- a/zemu/config.rb
+++ b/zemu/config.rb
@@ -234,7 +234,7 @@ class Timer8254 < Displayable
             @device = device
             @id = id
 
-            reset()
+            reset(true)
         end
 
         def mode=(m)
@@ -246,8 +246,8 @@ class Timer8254 < Displayable
             @device.log "Timer #{@id}: #{msg}"
         end
 
-        def reset
-            log "reset"
+        def reset(initial_reset=false)
+            log "reset" unless initial_reset
 
             @mode = MODE_UNDEFINED
             @count = nil

--- a/zemu/config.rb
+++ b/zemu/config.rb
@@ -221,6 +221,155 @@ class Timer < Displayable
     end
 end
 
+# 8254 Timer Simulation
+class Timer8254 < Displayable
+    # An individual timer in the 8254.
+    class Timer
+        MODE_UNDEFINED = -1
+        MODE_0 = 0
+
+        attr_accessor :mode
+
+        attr_reader :out
+
+        def initialize(id)
+            @id = id
+
+            reset()
+        end
+
+        def log(msg)
+            super "Timer #{@id}: #{msg}"
+        end
+
+        def reset
+            log "reset"
+
+            @mode = MODE_UNDEFINED
+            @count = nil
+            @next_count = nil
+
+            @lsb = nil
+
+            @out = 0
+        end
+
+        # Loads a byte into the counter.
+        # Counter value is loaded LSB-first.
+        def load_byte(val)
+            if @lsb.nil?
+                log "Load lsb: %08x" % val
+
+                @lsb = val
+            else
+                log "Load msb: %08x" % val
+
+                msb = val
+                initial_count = (msb << 8) | @lsb
+                @next_count = val
+            end
+        end
+
+        def load_count(val)
+            @next_count = val
+        end
+
+        def tick
+            # Mode 0.
+            # Decrements the timer if no count has been written.
+            # Otherwise, loads the count into the timer.
+            if @next_count.nil?
+                if @count.zero?
+                    log "count zero"
+                    @out = 1
+                else
+                    @count -= 1
+                end
+            else
+                @count = @next_count
+                @next_count = nil
+            end
+        end
+    end
+
+
+
+    # Constructor
+    #
+    # Takes a block used to set parameters.
+    # The following parameters can be set:
+    #
+    # * base_port: Base port of the device.
+    def initialize
+        super
+
+        @timers = []
+        3.times do
+            @timers << Timer.new
+        end
+    end
+
+    def params
+        super + %w(base_port)
+    end
+
+    def addressed?(port)
+        port >= base_port && port < (base_port + 4)
+    end
+
+    def write_control(value)
+        bcd = value & 0b0000_0001
+        m = (value & 0b0000_1110) >> 1
+        rw = (value & 0b0011_0000) >> 4
+        sc = (value & 0b1100_0000) >> 6
+
+        # Figure out which timer has been selected.
+        raise "Read-back command not supported" if sc > 2
+        timer = @timers[sc]
+
+        # Figure out which mode has been selected.
+        raise "Unsupported M val: #{m}" if m > 0
+        selected_mode = case m
+        when 0
+            Timer::MODE_0
+        end
+
+        # Figure out BCD or binary mode.
+        raise "BCD mode not supported" unless bcd == 0
+
+        # Figure out r/w mode.
+        # Only two-byte write mode supported currently.
+        raise "Unsupported R/W mode: #{rw}" unless rw == 3
+
+        # Reset the selected timer and select mode.
+        timer.reset()
+        timer.mode = selected_mode
+    end
+
+    def write_timer(addr, value)
+        timer = @timers[addr]
+
+        timer.load_byte(value)
+    end
+
+    def io_write(port, value)
+        return unless addressed?(port)
+
+        addr = port - base_port
+
+        case addr
+        when 0..2
+            write_timer(addr, value)
+        when 3
+            write_control(value)
+        end
+    end
+
+    def clock
+        @timers.each { |t| t.tick() }
+    end
+end
+
 # Serial Input/Output object
 #
 # Represents a serial connection between the emulated CPU
@@ -368,10 +517,9 @@ def zemu_config(instance_name, binary, disk, kernel_bin="kernel.bin")
             contents(0)[0x77f8] = 0x00
         end)
 
-        add_device (Timer.new do
+        add_device (Timer8254.new do
             name "timer"
-            io_port 0x10
-            period 0.02
+            base_port 0x10
         end)
 
         add_io (Serial6850.new do


### PR DESCRIPTION
I have assembled the banked RAM and timer boards for the z80 computer.

The timer board uses an 8254 programmable timer, so this branch implements changes in the kernel to support this.